### PR TITLE
[w6otx] upgrade w6otx-net to bookworm and bump workflow to ubuntu-23.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-20.04       # to match debian 11 bullseye
+    runs-on: ubuntu-22.04       # to match debian bookworm on w6otx-net
     
     strategy:
       matrix:


### PR DESCRIPTION
ubuntu-20.04 is no longer supported by github actions.